### PR TITLE
Update package.json license reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,5 @@
 		"type": "git",
 		"url": "git@github.com:webpack/raw-loader.git"
 	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://www.opensource.org/licenses/mit-license.php"
-		}
-	]
+	"license": "MIT"
 }


### PR DESCRIPTION
Scheme has changed. For example: running `npm view raw-loader license` in terminal returns `undefined` instead of `MIT`.
See the docs for further information: https://docs.npmjs.com/files/package.json#license