### PR TITLE
Update README example to use -loader suffix to reflect new requirement in Webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Usage
 
 ``` javascript
-var fileContent = require("raw!./file.txt");
+var fileContent = require("raw-loader!./file.txt");
 // => returns file.txt content as string
 ```
 


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra 