### PR TITLE
Fix Maintainers section look

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ import txt from 'raw-loader!./file.txt';
   <tbody>
     <tr>
       <td align="center">
-        <img width="150 height="150" src="https://github.com/sokra.png?s=150">
-        <br>
+        <img width="150" height="150" src="https://avatars.githubusercontent.com/sokra?v=3">
+        </br>
         <a href="https://github.com/sokra">Tobias Koppers</a>
       </td>
-    <tr>
-  <tbody>
+    </tr>
+  </tbody>
 </table>
 
 [npm]: https://img.shields.io/npm/v/raw-loader.svg


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fix Maintainer section HTML

**Did you add tests for your changes?**
No

**If relevant, did you update the README?**
Yes

**Summary**

Maintainers section HTML was incorrect, making the website look like this:
![image](https://cloud.githubusercontent.com/assets/1002461/22202322/92474168-e135-11e6-9884-b8a2b7a11ce7.png)

After the change it looks like this:
![image](https://cloud.githubusercontent.com/assets/1002461/22202342/a80ae964-e135-11e6-9deb-9d3f46b06932.png)

